### PR TITLE
feat: add Open Graph, Twitter and SEO metadata to root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,9 +21,49 @@ const display = Cinzel({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://tusst.dev"),
   title: "TUSST — The Ultimate Stellar Supreme Tutorial",
   description:
     "Hands-on, gamified coding challenges. Master Rust first, then ship real Soroban smart contracts on Stellar. No setup — just code.",
+  keywords: [
+    "Stellar",
+    "Soroban",
+    "Rust",
+    "smart contracts",
+    "learn to code",
+    "gamified",
+    "web3",
+  ],
+  authors: [{ name: "TUSST" }],
+  creator: "TUSST",
+  openGraph: {
+    title: "TUSST — The Ultimate Stellar Supreme Tutorial",
+    description:
+      "Hands-on, gamified coding challenges. Master Rust first, then ship real Soroban smart contracts on Stellar. No setup — just code.",
+    url: "https://tusst.dev",
+    siteName: "TUSST",
+    type: "website",
+    locale: "en_US",
+    images: [
+      {
+        url: "/sky-shattered.png",
+        width: 1200,
+        height: 630,
+        alt: "TUSST — forge your path from Rust to Stellar",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "TUSST — The Ultimate Stellar Supreme Tutorial",
+    description:
+      "Hands-on, gamified coding challenges. Master Rust first, then ship real Soroban smart contracts on Stellar. No setup — just code.",
+    images: ["/sky-shattered.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## What
Extends the root layout metadata (`src/app/layout.tsx`) with:
- `metadataBase`
- `keywords`
- `openGraph` (title, description, url, siteName, type, locale, image)
- `twitter` (summary_large_image card)
- `robots` (index/follow)

Uses the existing `/sky-shattered.png` asset as the social preview image.

## Why
Today only `title` and `description` are set, so sharing a TUSST link (Discord, X, etc.) produces no rich preview card and SEO is minimal. This is a small, low-risk, single-file improvement.

## Testing
- `npm run lint` ✓
- `npm run build` ✓
- No behavior/UI changes — metadata only.

## Notes
`metadataBase` uses `https://tusst.dev` as a placeholder — happy to adjust to the project's canonical production URL if there is one.