### PR TITLE
fix: shuffle lesson quiz/fill answer order

### DIFF
--- a/src/components/LessonSteps.tsx
+++ b/src/components/LessonSteps.tsx
@@ -6,7 +6,7 @@
 // The final "editor" step reuses LessonPlayer (server-graded, checks hidden).
 
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { LessonPlayer } from "@/components/LessonPlayer";
 import { Markdown } from "@/components/Markdown";
 import type { LessonStep } from "@/content/steps";
@@ -19,6 +19,57 @@ const PRAISE = ["Well forged!", "That's it!", "The runes approve.", "Flawless."]
 type Feedback = { correct: boolean; text: string } | null;
 
 const stepsDoneKey = (slug: string) => `tusst:steps-done:${slug}`;
+
+// A step's answer options in their shuffled display order, plus the index the
+// correct answer ended up at once shuffled.
+type ShuffledChoices = { displayOrder: string[]; correctIndex: number };
+
+// Fold the option text down to a 32-bit number (FNV-1a) to seed the shuffle.
+// We seed off the question's own text rather than Math.random so the shuffle is
+// deterministic: the server and the client then produce the exact same order,
+// which avoids a React hydration mismatch without needing a client-only effect.
+const hashOptionsToSeed = (options: string[]): number => {
+  const text = options.join(" ");
+  let hash = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+};
+
+// mulberry32 PRNG: a small deterministic generator. The same seed always yields
+// the same sequence of numbers, which is what makes the shuffle reproducible.
+const createSeededRandom = (seed: number): (() => number) => () => {
+  seed = (seed + 0x6d2b79f5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+};
+
+// Authored quiz/fill data always lists the correct option first (the answer
+// index is 0 for every question), so without shuffling the whole game is beaten
+// by always clicking the top option. This shuffles the options into a stable,
+// deterministic order and reports where the correct answer moved to. Theory and
+// editor steps have no options and return null.
+const shuffleStepChoices = (step: LessonStep): ShuffledChoices | null => {
+  let options: string[];
+  if (step.kind === "quiz") options = step.options;
+  else if (step.kind === "fill") options = step.choices;
+  else return null;
+
+  const correctOption = options[step.answer];
+  const nextRandom = createSeededRandom(hashOptionsToSeed(options));
+
+  // Fisher-Yates over a copy, so the original authored order stays untouched.
+  const displayOrder = [...options];
+  for (let i = displayOrder.length - 1; i > 0; i--) {
+    const swapWith = Math.floor(nextRandom() * (i + 1));
+    [displayOrder[i], displayOrder[swapWith]] = [displayOrder[swapWith], displayOrder[i]];
+  }
+
+  return { displayOrder, correctIndex: displayOrder.indexOf(correctOption) };
+};
 
 export function LessonSteps({
   lessonSlug,
@@ -49,11 +100,15 @@ export function LessonSteps({
   const [selected, setSelected] = useState<number | null>(null);
   const [feedback, setFeedback] = useState<Feedback>(null);
   const [done, setDone] = useState(false);
+  // Deterministic per-question shuffle, identical on server and client.
+  const shuffledChoicesByStep = useMemo(() => steps.map(shuffleStepChoices), [steps]);
 
   const total = steps.length;
   // Progress counts the congrats screen as 100%.
   const percent = done ? 100 : Math.round((index / total) * 100);
-  const step = steps[Math.min(index, total - 1)];
+  const safeIndex = Math.min(index, total - 1);
+  const step = steps[safeIndex];
+  const shuffledChoices = shuffledChoicesByStep[safeIndex];
 
   const advance = useCallback(() => {
     setSelected(null);
@@ -202,7 +257,7 @@ export function LessonSteps({
           <div className="mx-auto w-full max-w-xl">
             <Markdown>{step.question}</Markdown>
             <div className="mt-6 flex flex-col gap-3">
-              {step.options.map((opt, i) => {
+              {(shuffledChoices?.displayOrder ?? step.options).map((opt, i) => {
                 const isSel = selected === i;
                 const wrong = feedback && !feedback.correct && isSel;
                 const right = feedback?.correct && isSel;
@@ -253,13 +308,13 @@ export function LessonSteps({
                       : "border-dashed border-line-strong text-muted"
                   }`}
                 >
-                  {selected !== null ? step.choices[selected] : " "}
+                  {selected !== null ? (shuffledChoices?.displayOrder ?? step.choices)[selected] : " "}
                 </span>
                 {step.after}
               </pre>
             </div>
             <div className="mt-6 flex flex-wrap justify-center gap-3">
-              {step.choices.map((c, i) => (
+              {(shuffledChoices?.displayOrder ?? step.choices).map((c, i) => (
                 <button
                   key={i}
                   type="button"
@@ -365,7 +420,7 @@ export function LessonSteps({
                   disabled={selected === null}
                   onClick={() =>
                     step.kind === "quiz" || step.kind === "fill"
-                      ? check(step.answer, step.explain)
+                      ? check(shuffledChoices?.correctIndex ?? step.answer, step.explain)
                       : undefined
                   }
                   className="w-full rounded-full px-7 py-3.5 font-display text-[13px] font-bold uppercase tracking-[0.14em] text-[#0b0817] transition-transform hover:-translate-y-[1px] disabled:opacity-40 sm:w-auto"


### PR DESCRIPTION
## Why

Every multiple-choice lesson question (`quiz` and `fill` steps) authored the
correct option first in the array (`answer: 0`), and the player rendered the
options in raw array order with no shuffle. As a result, all 68 questions could
be passed simply by always clicking the first option.

## What changed

Options are now shuffled before being displayed, and the code tracks where the
correct answer moved to, comparing the selected option against that new position.

The shuffle is deterministic: the seed is derived from the question's own text
(FNV-1a hash + mulberry32 PRNG). This makes the server and client produce the
exact same order, avoiding a React hydration mismatch without a client-only
effect. The order is stable — it does not re-shuffle mid-question.

The data in `steps.ts` is left untouched: the fix covers all 68 questions purely
at render time.

## System impact

- `src/components/LessonSteps.tsx` — only changed file.
- Affects how `quiz` and `fill` steps are displayed and graded inside lessons.
- `theory` and `editor` steps are unaffected (they have no options).
- Each lesson's final coding challenge is graded server-side via `expectedOutput`,
  so it stays the same.

## Notes

- With 3 options, the correct answer still lands first ~1/3 of the time (it's
  truly random). Always clicking the first option now scores ~33% instead of
  100%. I chose not to force "never first" since that would create another
  exploitable pattern.
- No new dependencies.
- Typecheck and lint passing.

-----------------------------------------------------------------------------------
# PT-br 
## Motivo da mudança

Todas as questões de múltipla escolha das lições (steps do tipo `quiz` e `fill`)
tinham a resposta correta escrita como a primeira opção do array (`answer: 0`),
e o player exibia as opções na ordem crua, sem embaralhar. Resultado: dava para
passar todas as 68 questões simplesmente clicando sempre na primeira alternativa.

## A mudança

As opções agora são embaralhadas antes de serem exibidas, e o código rastreia
para onde a resposta correta foi, comparando a alternativa selecionada com essa
nova posição.

O embaralhamento é determinístico: a semente vem do próprio texto da questão
(hash FNV-1a + PRNG mulberry32). Isso garante que servidor e cliente gerem a
mesma ordem, evitando erro de *hydration* do React sem precisar de efeito só no
cliente. A ordem é estável — não re-embaralha no meio da questão.

Os dados em `steps.ts` não foram alterados: a correção resolve as 68 questões só
mudando a renderização.

## Onde impacta no sistema

- `src/components/LessonSteps.tsx` — único arquivo alterado.
- Afeta a exibição e a correção dos steps `quiz` e `fill` dentro das lições.
- Steps `theory` e `editor` não são afetados (não têm alternativas).
- O desafio de código final de cada lição é corrigido no servidor por
  `expectedOutput`, então continua igual.

## Notas

- Com 3 alternativas, a correta ainda cai na primeira posição ~1/3 das vezes
  (é aleatório de verdade). Clicar sempre na primeira agora acerta ~33% em vez
  de 100%. Optei por não forçar "nunca na primeira" porque isso criaria outro
  padrão explorável.
- Sem novas dependências.
- Typecheck e lint passando.
