### PR TITLE
feat: add CI/CD pipeline for Neon migrations and VPS deploy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# Paths that can touch production (Neon, the VPS sandbox, or the CI/CD
+# pipeline itself) require review from the infra owner, regardless of who
+# else reviews the rest of the PR.
+#
+# - prisma/           — SQL that runs against the real Neon database; this is
+#                        where the 2026-07-16 schema drift + progress
+#                        corruption incidents both started.
+# - runner/           — defines the untrusted-code sandbox (Docker isolation
+#                        flags); a regression here is a sandbox escape running
+#                        on the production VPS.
+# - runner-soroban/   — same, for the Soroban/Scout sandbox.
+# - .github/workflows/ — controls what runs with production secrets.
+# - deploy/           — the canonical copy of the VPS deploy script.
+# - .mcp.json         — the only third-party trust surface declared publicly
+#                        in this repo (a remote MCP server URL).
+
+/prisma/                @pedro-pelicioni
+/runner/                @pedro-pelicioni
+/runner-soroban/        @pedro-pelicioni
+/.github/workflows/     @pedro-pelicioni
+/deploy/                @pedro-pelicioni
+/.mcp.json              @pedro-pelicioni

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+# Validates PRs (including from forks) and non-main pushes. Deliberately
+# carries NO secrets and never touches the VPS or Neon — see deploy.yml for
+# that. This split keeps "workflow that accepts fork content" and "workflow
+# that holds production credentials" physically separate.
+
+on:
+  pull_request:
+  push:
+    branches-ignore: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      # prisma generate only reads schema.prisma — never connects. A dummy
+      # value keeps it from erroring on a missing DATABASE_URL.
+      DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy?schema=public"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci --no-audit --no-fund
+      - run: npm run lint
+      - run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,119 @@
+name: Deploy
+
+# Production pipeline: Neon migrations/seed, then sync the VPS runner. Never
+# triggered by pull_request/pull_request_target — only push to main (which
+# requires write access) or a manual, write-access-gated workflow_dispatch.
+# Both jobs sit behind the `deploy-production` Environment (required reviewer
+# + where the secrets live), so nothing here runs unattended. Named distinctly
+# from the pre-existing "Production" environment (Vercel's own GitHub App
+# creates that one for deployment-status tracking — unrelated to these
+# secrets, left untouched).
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_migration:
+        description: "Run migrate deploy + seed on Neon even if prisma/** didn't change"
+        type: boolean
+        default: false
+
+concurrency:
+  group: tusst-production-deploy
+  cancel-in-progress: false # never cancel a deploy/migration mid-flight — queue instead
+
+permissions:
+  contents: read
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      prisma: ${{ steps.filter.outputs.prisma }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        with:
+          base: ${{ github.event.before }}
+          filters: |
+            prisma:
+              - 'prisma/**'
+
+  migrate-neon:
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.prisma == 'true' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.force_migration == 'true')
+    runs-on: ubuntu-latest
+    environment: deploy-production
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci --no-audit --no-fund
+
+      - name: Preflight — refuse to run if the schema has drifted
+        env:
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+        run: |
+          set +e
+          OUT="$(npx prisma migrate status 2>&1)"
+          CODE=$?
+          set -e
+          echo "$OUT"
+          if echo "$OUT" | grep -qiE "drift|diverged"; then
+            echo "::error::Schema drift detected between Neon and the migration history. Aborting — investigate manually before running migrate deploy (see memory tusst-seed-safety for the incident this guards against)."
+            exit 1
+          fi
+          if [ "$CODE" -ne 0 ] && ! echo "$OUT" | grep -qi "have not yet been applied"; then
+            echo "::error::prisma migrate status failed unexpectedly — aborting."
+            exit 1
+          fi
+
+      - name: Apply migrations
+        env:
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+        run: npx prisma migrate deploy
+
+      - name: Seed (idempotent — explicit per-lesson slugs, see prisma/seed.ts)
+        env:
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+        run: npx prisma db seed
+
+  deploy-vps:
+    needs: [detect-changes, migrate-neon]
+    if: |
+      always() &&
+      needs.detect-changes.result == 'success' &&
+      (needs.migrate-neon.result == 'success' || needs.migrate-neon.result == 'skipped')
+    runs-on: ubuntu-latest
+    environment: deploy-production
+    steps:
+      - name: Pin the VPS host key (avoid TOFU on an ephemeral runner)
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ vars.VPS_HOST }} ${{ vars.VPS_HOST_KEY }}" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Load the dedicated deploy key
+        run: |
+          umask 077
+          printf '%s\n' "${{ secrets.VPS_CI_DEPLOY_KEY }}" > /tmp/tusst_ci_deploy
+          chmod 600 /tmp/tusst_ci_deploy
+
+      - name: Trigger the remote deploy (forced command ignores what we send)
+        run: |
+          ssh -i /tmp/tusst_ci_deploy \
+              -o StrictHostKeyChecking=yes -o BatchMode=yes -o ConnectTimeout=15 \
+              "${{ vars.VPS_SSH_USER }}@${{ vars.VPS_HOST }}" \
+              "deploy"
+
+      - name: Clean up the deploy key
+        if: always()
+        run: rm -f /tmp/tusst_ci_deploy

--- a/deploy/vps-deploy.sh
+++ b/deploy/vps-deploy.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Canonical, reviewable copy of the VPS deploy script.
+#
+# This file is versioned here for review (see .github/CODEOWNERS), but the
+# copy that actually runs on the VPS lives OUTSIDE the git tree, at
+# /usr/local/sbin/tusst-deploy.sh, promoted there manually by an operator
+# with their own SSH access. It is invoked only via the forced `command=` in
+# root's authorized_keys for the dedicated CI deploy key — that key can never
+# run anything else, and the CI pipeline can never rewrite this file itself,
+# even if the whole repo were compromised. See memory `tusst-vps-deploy` /
+# the CI/CD plan for the full rationale.
+#
+# To change deploy logic: edit this file, get it reviewed/merged, then an
+# operator manually copies it to /usr/local/sbin/tusst-deploy.sh over SSH
+# with their personal key. The CI pipeline never touches that path.
+
+set -euo pipefail
+
+# Never read anything from the SSH client's stdin, even if it tries to send
+# something — this script's own logic is the only thing that ever runs here.
+exec </dev/null
+
+REPO_DIR=/opt/tusst
+LOCK_FILE=/var/lock/tusst-deploy.lock
+HEALTH_URL=http://localhost:3000/api/internal/run
+MAX_HEALTH_WAIT=60
+
+log() {
+  echo "[tusst-deploy] $(date -u +%FT%TZ) $*"
+}
+
+# Whatever the SSH client asked for is logged for audit only — never eval'd
+# or executed. The forced command already guarantees this script is the only
+# thing that runs; this is defense-in-depth against a future edit mistake.
+log "client requested (ignored by design): ${SSH_ORIGINAL_COMMAND:-<empty>}"
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  log "another deploy is already running — exiting"
+  exit 1
+fi
+
+cd "$REPO_DIR"
+
+PREV_SHA="$(git rev-parse HEAD)"
+git fetch origin main --quiet
+NEW_SHA="$(git rev-parse origin/main)"
+
+if [ "$PREV_SHA" = "$NEW_SHA" ]; then
+  log "origin/main is already at $NEW_SHA — nothing to do"
+  exit 0
+fi
+
+CHANGED_PATHS="$(git diff --name-only "$PREV_SHA" "$NEW_SHA")"
+log "moving from $PREV_SHA to $NEW_SHA. Changed paths:"
+echo "$CHANGED_PATHS"
+
+git reset --hard "$NEW_SHA"
+npm ci --no-audit --no-fund
+
+if echo "$CHANGED_PATHS" | grep -q '^runner/'; then
+  log "rebuilding tusst-runner (runner/ changed)"
+  npm run runner:build
+fi
+
+if echo "$CHANGED_PATHS" | grep -q '^runner-soroban/'; then
+  log "rebuilding tusst-soroban-runner (runner-soroban/ changed — this is the expensive one)"
+  npm run runner:soroban:build
+fi
+
+npm run build
+
+read_runner_secret() {
+  grep -E '^RUNNER_SHARED_SECRET=' "$REPO_DIR/.env" | cut -d= -f2- | tr -d '"'
+}
+
+restart_and_check() {
+  systemctl restart tusst.service
+  local secret waited=0
+  secret="$(read_runner_secret)"
+  while [ "$waited" -lt "$MAX_HEALTH_WAIT" ]; do
+    if systemctl is-active --quiet tusst.service && \
+       curl -sf -X POST "$HEALTH_URL" \
+         -H "x-runner-secret: $secret" -H 'Content-Type: application/json' \
+         --data '{"code":"fn main() { println!(\"ok\"); }"}' \
+         | grep -q '"compiled":true'; then
+      return 0
+    fi
+    sleep 3
+    waited=$((waited + 3))
+  done
+  return 1
+}
+
+if restart_and_check; then
+  log "deploy OK — healthy at $NEW_SHA"
+  exit 0
+fi
+
+log "HEALTH CHECK FAILED at $NEW_SHA — rolling back to $PREV_SHA"
+git reset --hard "$PREV_SHA"
+npm ci --no-audit --no-fund
+npm run build
+docker image inspect tusst-runner:latest >/dev/null 2>&1 || npm run runner:build
+
+if restart_and_check; then
+  log "ROLLBACK OK — back at $PREV_SHA. Deploy of $NEW_SHA FAILED and was reverted."
+  exit 1 # keep the run red even though the rollback itself succeeded
+else
+  log "CRITICAL: rollback to $PREV_SHA also did not come back healthy. Needs manual intervention NOW."
+  exit 2
+fi

--- a/src/components/ide/IdeTutorial.tsx
+++ b/src/components/ide/IdeTutorial.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMessages } from "@/i18n/client";
 import { fmt } from "@/i18n/format";
 
@@ -22,23 +22,31 @@ const POPOVER_WIDTH = 320;
 const POPOVER_EST_HEIGHT = 200;
 const MARGIN = 12;
 
+function measureTarget(stepKey: string): DOMRect | null {
+  const el = document.querySelector(`[data-tutorial-id="${stepKey}"]`);
+  return el ? el.getBoundingClientRect() : null;
+}
+
 export function IdeTutorial({ onDone }: { onDone: () => void }) {
   const m = useMessages();
   const [index, setIndex] = useState(0);
-  const [rect, setRect] = useState<DOMRect | null>(null);
-
-  const stepKey = STEP_ORDER[index];
-
-  const measure = useCallback(() => {
-    const el = document.querySelector(`[data-tutorial-id="${stepKey}"]`);
-    setRect(el ? el.getBoundingClientRect() : null);
-  }, [stepKey]);
+  // Resize is the only genuine external event here — the listener only ever
+  // sets state from inside its own callback, never synchronously in the
+  // effect body, so it counts as the "subscribe + setState in a callback"
+  // pattern rather than the "setState in an effect" one.
+  const [resizeTick, setResizeTick] = useState(0);
 
   useEffect(() => {
-    measure();
-    window.addEventListener("resize", measure);
-    return () => window.removeEventListener("resize", measure);
-  }, [measure]);
+    const onResize = () => setResizeTick((t) => t + 1);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  const stepKey = STEP_ORDER[index];
+  // Derived at render time, not in an effect — resizeTick is only a
+  // recompute trigger, the DOM query itself has no dependency of its own.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const rect = useMemo(() => measureTarget(stepKey), [stepKey, resizeTick]);
 
   const step = m.ide.tutorial.steps[stepKey];
   const isLast = index === STEP_ORDER.length - 1;


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — lint/build validation on PRs (including forks), no production secrets.
- Adds `.github/workflows/deploy.yml` — production pipeline: migrate+seed Neon (only when `prisma/**` changes) then sync the VPS runner, both gated by the `deploy-production` Environment (required reviewer).
- Adds `deploy/vps-deploy.sh` — canonical copy of the script promoted to `/usr/local/sbin/tusst-deploy.sh` on the VPS, invoked only via a forced SSH command tied to a dedicated, restricted deploy key.
- Adds `.github/CODEOWNERS` protecting `prisma/`, `runner/`, `runner-soroban/`, `.github/workflows/`, `deploy/`, `.mcp.json`.

## Test plan
- [x] `ci.yml` runs on this PR (lint + build) — confirm it's green before merging.
- [ ] After merging: trigger `deploy.yml` via `workflow_dispatch` first (not waiting for the next real push) to observe `deploy-vps` end-to-end, including the health-check.
- [ ] Confirm the Environment approval gate actually pauses the run until approved.