### PR TITLE
feat: add security policy, Dependabot config, and cargo-audit workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Workspace with two members (tusst-runner, tusst-syntest) — one entry
+  # covers both, Dependabot resolves against the workspace Cargo.lock.
+  - package-ecosystem: "cargo"
+    directory: "/runner"
+    schedule:
+      interval: "weekly"
+
+  # No Cargo.lock committed here on purpose (it's generated fresh inside the
+  # Docker build — see runner-soroban/Dockerfile). Dependabot still resolves
+  # against the pinned versions in Cargo.toml, just with weaker precision
+  # than /runner. See SECURITY.md / runner-soroban/Dockerfile for the pins
+  # this directory carries (ed25519-dalek, etc).
+  - package-ecosystem: "cargo"
+    directory: "/runner-soroban/warm"
+    schedule:
+      interval: "weekly"
+
+  # Keeps the SHA-pinned actions in ci.yml/deploy.yml/cargo-audit.yml from
+  # going stale forever — pinning by SHA means nothing else would ever
+  # surface that a newer release exists.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,41 @@
+name: Cargo Audit
+
+# CodeQL's default setup doesn't cover Rust, so the sandbox crates (runner/,
+# runner-soroban/) would otherwise have no dependency-vulnerability scanner
+# at all. This closes that gap using the RustSec Advisory Database. Safe to
+# run on fork PRs too — read-only, no secrets, no production access.
+
+on:
+  push:
+    paths: ["runner/**", "runner-soroban/**"]
+  pull_request:
+    paths: ["runner/**", "runner-soroban/**"]
+  schedule:
+    # Weekly, independent of any code change — the point is to catch newly
+    # published advisories against dependencies that have been pinned and
+    # untouched for a while.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  audit-runner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit
+        working-directory: runner
+
+  audit-runner-soroban:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - run: cargo install cargo-audit --locked
+      - name: Audit (no committed lockfile here — generate one fresh)
+        run: cargo generate-lockfile && cargo audit
+        working-directory: runner-soroban/warm

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+TUSST doesn't ship versioned releases — only `main` is meaningful, so there
+are no "supported versions" beyond it.
+
+## Reporting a vulnerability
+
+Please use GitHub's **private vulnerability reporting** instead of a public
+issue: go to the [Security tab](https://github.com/pedro-pelicioni/tusst/security)
+and click **"Report a vulnerability."** That sends the report directly and
+privately to the maintainer — it's the preferred channel and doesn't require
+sharing any contact detail publicly.
+
+We'll acknowledge reports as soon as we see them and keep you posted while a
+fix is worked out. Please don't open a public issue or PR for anything that
+could be actively exploited before a fix ships.
+
+## Scope
+
+The highest-impact surface in this project is the **untrusted code execution
+sandbox**: `runner/` and `runner-soroban/` define the Docker isolation used to
+compile and run submitted Rust/Soroban code (`--network none`, `--cap-drop
+ALL`, non-root user, resource/time limits, one throwaway container per run).
+A regression there — e.g. a dropped isolation flag — is a sandbox escape
+running on the production host, and is the category of report we most want
+to hear about quickly.
+
+`.mcp.json` declares a remote MCP server (`stellar-raven`) as the only
+third-party trust surface checked into this repo. If you find a concern with
+that dependency specifically, it's worth flagging too.
+
+## What's out of scope
+
+- Findings that require physical access to the deployment host.
+- Missing security headers or best-practice suggestions with no
+  demonstrated impact — feel free to open those as a regular issue instead.
+- Automated scanner output without manual verification that it applies here.


### PR DESCRIPTION
## Summary
- `SECURITY.md` — points reporters at GitHub's private vulnerability reporting instead of a public issue; documents the sandbox (`runner/`, `runner-soroban/`) as the highest-impact surface.
- `.github/dependabot.yml` — npm (root), cargo (`/runner` workspace + `/runner-soroban/warm`), and github-actions (keeps the SHA-pinned actions in `ci.yml`/`deploy.yml` from going stale forever).
- `.github/workflows/cargo-audit.yml` — closes the Rust gap CodeQL's default setup leaves (no Rust support), against the RustSec Advisory Database. Runs on push/PR touching `runner/**`/`runner-soroban/**` plus a weekly cron.

Enabled directly via the API in this same pass (not part of this PR, already live): Dependabot alerts, Dependabot security updates, private vulnerability reporting, secret scanning + push protection, CodeQL default setup (JS/TS).

## Test plan
- [x] `cargo audit` verified locally against both `runner/` and a freshly generated `runner-soroban/warm` lockfile — clean (only 2 non-blocking "unmaintained crate" warnings in the latter).
- [ ] After merging: trigger `cargo-audit.yml` via `workflow_dispatch` to confirm the pinned `dtolnay/rust-toolchain` action resolves correctly in CI.