### PR TITLE
fix(ci): don't fail auto-merge when Dependabot supersedes its own PR

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -47,5 +47,17 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Dependabot routinely supersedes its own PRs — it opens one per
+          # dependency, then replaces them with the grouped PR moments later.
+          # This workflow can be mid-flight when that happens, and approving a
+          # closed PR fails with "Pull request is closed
+          # (enablePullRequestAutoMerge)". That's a race, not a problem, so
+          # don't paint the Actions tab red over it.
+          state="$(gh pr view "$PR_URL" --json state --jq .state)"
+          if [ "$state" != "OPEN" ]; then
+            echo "PR is already $state (superseded by Dependabot) — nothing to do."
+            exit 0
+          fi
+
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Follow-up to #36, from watching the first real Dependabot cycle run.

Dependabot opens one PR per dependency and then replaces them with the grouped PR seconds later. When the auto-merge workflow is already in flight against one of the originals, it dies on:

```
PR_URL: https://github.com/pedro-pelicioni/tusst/pull/40
GraphQL: Pull request is closed (enablePullRequestAutoMerge)
```

Nothing is actually wrong — the PR it was handed simply stopped existing. But it leaves a red run in the Actions tab, which is the same "failed for a trivial reason" noise #36 exists to remove.

Fix: re-read the PR state at run time and exit 0 when it is no longer open.

## The rest of the cycle is working

From the first post-#36 run:

- 13 PRs → **7**, with `npm-minor-patch` carrying **10 updates** in one PR and `cargo-runner-minor-patch` carrying 4
- the `soroban-sdk` ignore rule held — instead of the major `=27.0.2` that old PR #31 proposed, Dependabot now offers only the patch `=26.1.1`
- eslint `9.39.4 → 10.8.0` (major) correctly did **not** get auto-merge
- the npm PRs outside CODEOWNERS paths got a bot approval; the ones touching `runner/`, `runner-soroban/` and `.github/workflows/` still read `REVIEW_REQUIRED`, as intended
- `2bde25b` — js-yaml `4.2.0 → 4.3.0` (#42) merged itself and deleted its branch, end to end