### PR TITLE
fix(runner-soroban): don't abort the image build when ed25519-dalek 3.x is absent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,15 @@ updates:
       npm-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # eslint-config-next still bundles an eslint-plugin-react that calls
+      # context.getFilename(), removed in ESLint 10 — `npm run lint` dies with
+      # "Error while loading rule 'react/display-name'" before linting a single
+      # file. Not our bug and not fixable here; the bump can only land once
+      # eslint-config-next supports v10, so drop this entry then rather than
+      # letting the same red PR reappear every week.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   # Workspace with two members (tusst-runner, tusst-syntest) — one entry
   # covers both, Dependabot resolves against the workspace Cargo.lock.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,11 +84,22 @@ jobs:
       # the Dockerfile does. The ed25519-dalek downgrade is load-bearing: 3.x
       # breaks soroban-env-host's testutils through an open ">=2.0.0" req
       # upstream.
+      #
+      # Conditional, and mirrored in runner-soroban/Dockerfile: `cargo update
+      # -p <pkg>@<ver>` is a hard error when that exact version isn't in the
+      # graph, and soroban-sdk 26.1.1 already resolves ed25519-dalek to 2.2.0
+      # by itself. Assert the outcome rather than assuming the command applies.
       - name: Resolve the lockfile the way the image does
         working-directory: runner-soroban/warm
         run: |
           cargo generate-lockfile
-          cargo update -p ed25519-dalek@3.0.0 --precise 2.2.0
+          if cargo pkgid ed25519-dalek@3.0.0 >/dev/null 2>&1; then
+            cargo update -p ed25519-dalek@3.0.0 --precise 2.2.0
+          fi
+          if grep -A1 '^name = "ed25519-dalek"$' Cargo.lock | grep -q '^version = "3\.'; then
+            echo "::error::ed25519-dalek 3.x survived the pin — it breaks soroban-env-host testutils. See runner-soroban/Dockerfile."
+            exit 1
+          fi
 
       # The warm contract is a bare `ping` that never links the OZ crates, so a
       # bad pin still COMPILES — building alone would not have caught PR #31

--- a/runner-soroban/Dockerfile
+++ b/runner-soroban/Dockerfile
@@ -48,8 +48,20 @@ WORKDIR /opt/warm
 # ed25519-dalek 3.x breaks soroban-env-host's testutils (open ">=2.0.0" req
 # upstream); pin 2.2.0 in the lockfile, which ships in the image and governs
 # every offline user build.
+#
+# Conditional, because `cargo update -p <pkg>@<ver>` is a hard error when that
+# exact version isn't in the graph: soroban-sdk 26.1.1 already resolves
+# ed25519-dalek to 2.2.0 on its own, so the unconditional form aborted the
+# image build on a routine patch bump. Assert the outcome instead of assuming
+# the command applies.
 RUN cargo generate-lockfile \
-    && cargo update -p ed25519-dalek@3.0.0 --precise 2.2.0 \
+    && if cargo pkgid ed25519-dalek@3.0.0 >/dev/null 2>&1; then \
+         cargo update -p ed25519-dalek@3.0.0 --precise 2.2.0; \
+       fi \
+    && if grep -A1 '^name = "ed25519-dalek"$' Cargo.lock | grep -q '^version = "3\.'; then \
+         echo "ed25519-dalek 3.x survived the pin — it breaks soroban-env-host testutils"; \
+         exit 1; \
+       fi \
     && cargo fetch
 RUN stellar contract build
 RUN cargo test --no-run && cargo test


### PR DESCRIPTION
Diagnosing the two remaining red Dependabot PRs. One of them turned out to be a real bug in the production image build.

## #38 — `soroban-sdk =26.1.0` → `=26.1.1`

Went red on the new `build-runner-soroban` job:

```
error: package ID specification `ed25519-dalek@3.0.0` did not match any packages
help: there are similar package ID specifications:
  ed25519-dalek@2.2.0
```

The pin exists because ed25519-dalek 3.x breaks soroban-env-host's testutils. But `cargo update -p <pkg>@<ver>` is a **hard error** when that exact version is not in the graph, and soroban-sdk 26.1.1 already resolves ed25519-dalek to 2.2.0 by itself. So the pin's goal is met while the command enforcing it blows up.

**This was never CI-only.** The identical line sits in `runner-soroban/Dockerfile` inside a `RUN ... && ...` chain:

```dockerfile
RUN cargo generate-lockfile \
    && cargo update -p ed25519-dalek@3.0.0 --precise 2.2.0 \
    && cargo fetch
```

Merging #38 would have aborted the production image build. The job added in #36 caught a latent bug rather than reporting a false one.

Both copies now downgrade only when 3.0.0 is actually present, then assert no 3.x entry survived — checking the outcome instead of assuming the command applies. Verified against both graphs:

| soroban-sdk | 3.0.0 in graph | action | 3.x left |
|---|---|---|---|
| `=26.1.0` | yes (alongside 2.2.0) | downgrade runs | 0 |
| `=26.1.1` | no | skipped | 0 |

## #45 — `eslint 9.39.4` → `10.8.0`

Genuine upstream incompatibility, nothing to fix here:

```
ESLint: 10.8.0
TypeError: Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function
```

`eslint-config-next` still bundles an `eslint-plugin-react` that calls `context.getFilename()`, removed in ESLint 10 — `npm run lint` dies before linting a single file. The bump can only land once eslint-config-next supports v10, so major eslint bumps are now ignored; without that, the same red PR reappears every week. Drop the entry when upstream catches up.

After this, #45 can be closed and #38 should go green on its next rebase.