### PR TITLE
fix(deploy): run the deploy detached so a dropped SSH doesn't kill it

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,8 +114,14 @@ jobs:
 
       - name: Trigger the remote deploy (forced command ignores what we send)
         run: |
+          # ServerAlive*: the deploy streams a log that can go quiet for a long
+          # stretch while the Soroban image builds. Keepalives stop an idle
+          # NAT/firewall from silently dropping the TCP connection. The build
+          # itself is detached host-side (see deploy/vps-deploy.sh), so a drop
+          # is no longer fatal — this just keeps us watching.
           ssh -i /tmp/tusst_ci_deploy \
               -o StrictHostKeyChecking=yes -o BatchMode=yes -o ConnectTimeout=15 \
+              -o ServerAliveInterval=30 -o ServerAliveCountMax=10 \
               "${{ vars.VPS_SSH_USER }}@${{ vars.VPS_HOST }}" \
               "deploy"
 

--- a/deploy/vps-deploy.sh
+++ b/deploy/vps-deploy.sh
@@ -22,8 +22,12 @@ exec </dev/null
 
 REPO_DIR=/opt/tusst
 LOCK_FILE=/var/lock/tusst-deploy.lock
+DEPLOY_LOG=/var/log/tusst-deploy.log
+STATUS_FILE=/run/tusst-deploy.status
+PID_FILE=/run/tusst-deploy.pid
 HEALTH_URL=http://localhost:3000/api/internal/run
 MAX_HEALTH_WAIT=60
+SELF="$(readlink -f "$0")"
 
 log() {
   echo "[tusst-deploy] $(date -u +%FT%TZ) $*"
@@ -34,10 +38,90 @@ log() {
 # thing that runs; this is defense-in-depth against a future edit mistake.
 log "client requested (ignored by design): ${SSH_ORIGINAL_COMMAND:-<empty>}"
 
-exec 9>"$LOCK_FILE"
-if ! flock -n 9; then
-  log "another deploy is already running — exiting"
-  exit 1
+# ---------------------------------------------------------------------------
+# Supervisor / worker split.
+#
+# The deploy can rebuild the Soroban image, which takes tens of minutes and
+# emits nothing at all while Scout compiles its detectors. Running that inside
+# the SSH session meant a dropped connection killed the build mid-flight:
+# `Timeout, server not responding` after 20 minutes of silence, image left
+# unbuilt, tree left advanced.
+#
+# So the real work runs detached (setsid, own session, no controlling
+# terminal) and writes to $DEPLOY_LOG. This invocation only streams that log
+# and exits with the worker's status. If the connection dies, the worker keeps
+# going — and the next invocation attaches to it instead of starting a second
+# one.
+#
+# `--worker` is set by this script re-executing itself, never by the client:
+# SSH_ORIGINAL_COMMAND is ignored (above) and the forced command passes no
+# arguments.
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--worker" ]; then
+  exec 9>"$LOCK_FILE"
+  if ! flock -n 9; then
+    log "another deploy is already running — exiting"
+    exit 1
+  fi
+  # Publish the pid only once the lock is actually held, so the supervisor
+  # can tell "still working" from "died" without racing worker startup.
+  echo "$$" >"$PID_FILE"
+  # Record the exit status wherever the worker stops, so the supervisor can
+  # report it — including the rollback paths, which exit non-zero on purpose.
+  record_status() { echo "$?" >"$STATUS_FILE"; }
+  trap record_status EXIT
+else
+  # Distinguish "lock held" from "flock is broken/missing": without this, any
+  # flock failure looks identical to a running deploy and the supervisor waits
+  # for a worker it never started.
+  if ! command -v flock >/dev/null 2>&1; then
+    log "flock is not available on this host — refusing to deploy"
+    exit 1
+  fi
+
+  if flock -n "$LOCK_FILE" true; then
+    : >"$DEPLOY_LOG"
+    rm -f "$STATUS_FILE" "$PID_FILE"
+    setsid nohup "$SELF" --worker >"$DEPLOY_LOG" 2>&1 </dev/null &
+    log "started detached worker — streaming $DEPLOY_LOG (a dropped connection no longer kills it)"
+  else
+    log "a deploy is already running — attaching to it rather than starting a second"
+  fi
+
+  tail -n +1 -f "$DEPLOY_LOG" &
+  TAIL_PID=$!
+  # shellcheck disable=SC2064
+  trap "kill $TAIL_PID 2>/dev/null || true" EXIT
+
+  # Liveness is tracked by pid, not by the lock: a freshly spawned worker has
+  # not acquired the lock yet, so testing the lock here reports a healthy
+  # worker as vanished.
+  waited=0
+  while [ ! -f "$PID_FILE" ] && [ ! -f "$STATUS_FILE" ]; do
+    waited=$((waited + 1))
+    if [ "$waited" -gt 30 ]; then
+      log "worker never came up — check $DEPLOY_LOG on the host"
+      exit 1
+    fi
+    sleep 1
+  done
+
+  while [ ! -f "$STATUS_FILE" ]; do
+    WORKER_PID="$(cat "$PID_FILE" 2>/dev/null || true)"
+    if [ -n "$WORKER_PID" ] && ! kill -0 "$WORKER_PID" 2>/dev/null; then
+      # Re-check once: the pid can be gone a beat before the status lands.
+      sleep 3
+      [ -f "$STATUS_FILE" ] && break
+      log "worker (pid $WORKER_PID) exited without recording a status — check $DEPLOY_LOG on the host"
+      exit 1
+    fi
+    sleep 5
+  done
+
+  sleep 1
+  STATUS="$(cat "$STATUS_FILE")"
+  log "worker finished with status $STATUS"
+  exit "$STATUS"
 fi
 
 cd "$REPO_DIR"


### PR DESCRIPTION
The deploy of #51 got further than any before it — `npm ci` passed on npm 11, the Soroban vendoring step passed — and then died here:

```
#25 [21/24] RUN ... cargo scout-audit ...
#25 1.740 [INFO] Compiling detectors...
  (20 minutes of no output at all)
Timeout, server 157.230.210.52 not responding.
```

**Not a build failure.** The SSH connection dropped and took the build with it. The host was fine throughout:

```
16:39:28 up 12 days, load average: 0.00, 0.00, 0.00
Mem: 7.8Gi total, 7.0Gi available    Swap: 4.0Gi (1.5Mi used)
no OOM kills, disk 23%
```

Scout compiles its detectors for tens of minutes without printing anything, and a silent connection does not survive that. Tying a 30-minute build to a live SSH session was always fragile — it had just never been exercised, because the deploy only rebuilds that image when `runner-soroban/` changes and nothing had touched it in 12 days.

## The fix

The script splits into **supervisor** and **worker**:

- the worker does the real work under `setsid`, in its own session, writing to `/var/log/tusst-deploy.log` and recording its exit status
- the SSH invocation only streams that log and exits with the worker's status
- a dropped connection leaves the worker running, and the next invocation **attaches** to it rather than starting a second

Two details worth reviewing:

**Liveness is tracked by pid, not by the lock.** A freshly spawned worker has not acquired the lock yet, so testing the lock there reports a healthy worker as vanished — an earlier draft of this did exactly that, and the test below caught it.

**The supervisor refuses to run if `flock` is missing**, instead of mistaking that for "a deploy is already running" and then waiting on a worker it never started.

`deploy.yml` gains `ServerAliveInterval`/`ServerAliveCountMax` so an idle NAT or firewall stops silently dropping the connection while the log is quiet. That is now a convenience rather than the thing keeping the build alive.

## Verified on the VPS itself

| scenario | expected | result |
|---|---|---|
| supervisor killed mid-run | worker survives, records status | worker alive after kill, status `7` recorded |
| full cycle | status propagates, no false "vanished" | supervisor exited `7` |
| second supervisor vs running deploy | attaches, one worker only | `attaching to it rather than starting a second`, exit `7`, worker count `1` |

## Current production state

Unchanged by this PR and still needing attention: the box is at `e70b5be` with a build from 06:38 and a 12-day-old Soroban image. A detached recovery build is running on it now to close that gap; the service has deliberately **not** been restarted.

Note that `HEAD == origin/main` on the host right now, so until it moves the old script would log `nothing to do` and exit green — the exact trap #51 describes.

## After merging

Promote the script, as always outside CI:

```
scp deploy/vps-deploy.sh root@<host>:/usr/local/sbin/tusst-deploy.sh
```

This is the third time a fix has landed in the repo but not on the box. Worth considering a check that compares the two and warns when they drift.
