### PR TITLE
fix(deploy): pin npm 11 in migrate-neon

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,16 @@ jobs:
         with:
           node-version: "22"
           cache: "npm"
+
+      # Same pin as ci.yml, and for the same reason: Dependabot regenerates
+      # package-lock.json with npm 11, which prunes the `optional: true,
+      # peer: true` entries (typescript@4.9.5 under stellar-wallets-kit,
+      # utf-8-validate@5.0.10 under walletconnect). Node 22 ships npm 10,
+      # whose `npm ci` then rejects the lockfile as out of sync. ci.yml has
+      # carried this pin for a while; this job never did, so a lockfile that
+      # passed CI could still fail the deploy — which is exactly what happened.
+      - run: npm install -g npm@11
+
       - run: npm ci --no-audit --no-fund
 
       - name: Preflight — refuse to run if the schema has drifted


### PR DESCRIPTION
## Why

`migrate-neon` failed on the first deploy after Dependabot #64:

```
npm error Missing: typescript@4.9.5 from lock file
npm error Missing: utf-8-validate@5.0.10 from lock file
```

#64 regenerated `package-lock.json` with npm 11, which prunes the
`optional: true, peer: true` entries. Node 22 ships npm 10, whose `npm ci`
rejects that lockfile as out of sync.

`ci.yml:47` has carried `npm install -g npm@11` for exactly this reason, and
`deploy/vps-deploy.sh:161` upgrades itself. `migrate-neon` was the only
consumer of the lockfile without the pin — so a lockfile that passes CI could
still fail the deploy, which is what happened. `deploy-vps` was skipped as a
dependency, so the runner image was not rebuilt either.

Not caused by #65: neither of its commits touches `package-lock.json`. Any
deploy touching `prisma/**` after #64 would have hit this.

## After merging

The path filter watches `prisma/**` and the content catalogues, not
`.github/**`, so this merge alone will not re-run the seed. Trigger it:

```
gh workflow run Deploy -f force_migration=true --ref main
```