### PR TITLE
fix(i18n): the retired vocabulary the rename pass left behind

### DIFF
--- a/src/i18n/messages/en/journey.ts
+++ b/src/i18n/messages/en/journey.ts
@@ -46,7 +46,7 @@ export const journey = {
       kicker: "see it in rust",
       optional: "optional deep-dive",
       cta: "Open the Rust lesson",
-      locked: "Unlocks with Campaign Act {numeral}",
+      locked: "Unlocks with Campaign section {numeral}",
     },
     lab: {
       kicker: "hands-on lab",

--- a/src/i18n/messages/en/lesson.ts
+++ b/src/i18n/messages/en/lesson.ts
@@ -13,15 +13,15 @@ export const lesson = {
 
   // LessonSteps (step player)
   praise: ["Nicely done.", "That's it.", "Correct.", "Clean."],
-  incorrect: "Not quite — study the rune again.",
+  incorrect: "Not quite — read that part again.",
   skirmishComplete: "lesson complete",
   doneSignedIn:
-    "The beacon flickers a little brighter. Your progress is carved into the Ledgerstone.",
+    "Progress saved to your account.",
   doneAnonymous:
     "Nothing here is saved yet. Create a free account to keep your progress and collect the section cards.",
   saveProgress: "Save my progress",
   nextSkirmish: "Next lesson ›",
-  backToAct: "Back to the act",
+  backToAct: "Back to the section",
   exitLesson: "Exit lesson",
   previousStep: "Previous step",
   nextStep: "Next step",
@@ -57,7 +57,7 @@ export const lesson = {
   mentorLimit:
     "the mentor rests — you've used today's hints for this lesson. The scroll's own hints remain:",
   mentorUnavailable:
-    "the mentor is away from the forge — the scroll's hints may help:",
+    "the mentor is unavailable — these hints may help:",
   goldCoinAlt: "Gold coin",
   goldEarned: "+{gold} gold",
   goldFirstReveal:

--- a/src/i18n/messages/en/onboarding.ts
+++ b/src/i18n/messages/en/onboarding.ts
@@ -9,7 +9,7 @@ export const onboarding = {
   welcomeBodyRust: "Rust",
   welcomeBody2: " programs and ",
   welcomeBodySoroban: "Soroban contracts",
-  welcomeBody3: " on Stellar — one small rune at a time.",
+  welcomeBody3: " on Stellar — one small step at a time.",
 
   // Question headings.
   goalQuestion: "Why are you learning to code?",
@@ -36,7 +36,7 @@ export const onboarding = {
   xpLevels: [
     {
       label: "NONE",
-      blurb: "You've never written a rune. Perfect — the Citadel was built for you.",
+      blurb: "You have never written a line of code. Perfect — this track starts there.",
     },
     {
       label: "LOW",

--- a/src/i18n/messages/pt/home.ts
+++ b/src/i18n/messages/pt/home.ts
@@ -25,7 +25,7 @@ export const home = {
       blurb:
         "Oito seções, de Rust básico a contratos Soroban, corrigidas num sandbox de verdade. Opcional, e o jeito mais rápido de sujar as mãos.",
       cta: "Marchar na Campanha",
-      progress: "{done}/{total} atos vencidos",
+      progress: "{done}/{total} seções concluídas",
     },
     advanced: {
       label: "se você já entrega",

--- a/src/i18n/messages/pt/journey.ts
+++ b/src/i18n/messages/pt/journey.ts
@@ -46,7 +46,7 @@ export const journey = {
       kicker: "ver em rust",
       optional: "aprofundamento opcional",
       cta: "Abrir a lição de Rust",
-      locked: "Destrava com o Ato {numeral} da Campanha",
+      locked: "Destrava com a seção {numeral} da Campanha",
     },
     lab: {
       kicker: "lab prático",

--- a/src/i18n/messages/pt/lesson.ts
+++ b/src/i18n/messages/pt/lesson.ts
@@ -21,7 +21,7 @@ export const lesson = {
     "Nada aqui foi salvo ainda. Crie uma conta gratuita para guardar seu progresso e colecionar as cartas das seções.",
   saveProgress: "Salvar meu progresso",
   nextSkirmish: "Próxima lição ›",
-  backToAct: "Voltar ao ato",
+  backToAct: "Voltar à seção",
   exitLesson: "Sair da lição",
   previousStep: "Passo anterior",
   nextStep: "Próximo passo",

--- a/src/i18n/messages/pt/onboarding.ts
+++ b/src/i18n/messages/pt/onboarding.ts
@@ -9,7 +9,7 @@ export const onboarding = {
   welcomeBodyRust: "Rust",
   welcomeBody2: " e ",
   welcomeBodySoroban: "contratos Soroban",
-  welcomeBody3: " na Stellar — uma pequena runa de cada vez.",
+  welcomeBody3: " na Stellar — um pequeno passo de cada vez.",
 
   // Títulos das perguntas.
   goalQuestion: "Por que você está aprendendo a programar?",
@@ -36,7 +36,7 @@ export const onboarding = {
   xpLevels: [
     {
       label: "NENHUMA",
-      blurb: "Você nunca escreveu uma runa. Perfeito — a Cidadela foi construída para você.",
+      blurb: "Você nunca escreveu uma linha de código. Perfeito — esta trilha começa aí.",
     },
     {
       label: "POUCA",
@@ -49,7 +49,7 @@ export const onboarding = {
   ],
 
   // Prova social.
-  proofHeading: "Os anciões já forjaram muitos aprendizes",
+  proofHeading: "Builders que terminaram a trilha",
   proofBody:
     "Código de verdade, corrigido por testes ocultos, direto no seu navegador. Sem setup local, sem toolchain para instalar.",
 

--- a/src/i18n/messages/pt/pages.ts
+++ b/src/i18n/messages/pt/pages.ts
@@ -4,7 +4,7 @@ export const pages = {
     kicker: "a estrada opcional",
     title: "Campanha de Rust",
     optionalNote:
-      "A trilha de maestria. Cada ato é opcional — e cada ato te deixa mais afiado. A Jornada aponta para cá sempre que você quiser o Rust por trás de um conceito.",
+      "A trilha de aprofundamento. Cada seção é opcional — e cada uma te deixa mais afiado. A Jornada aponta para cá sempre que você quiser o Rust por trás de um conceito.",
   },
   path: {
     kicker: "trilha da campanha",
@@ -29,7 +29,7 @@ export const pages = {
     actLink: "Seção {numeral} — {title}",
     unassigned: "não atribuída",
     footnote:
-      "as cartas são progressão cosmética — não trazem vantagem de gameplay. edições raras são concedidas por completar um ato de forma impecável. a reivindicação on-chain chega com o projeto final de Soroban.",
+      "as cartas são puramente cosméticas — não dão vantagem nenhuma e não travam conteúdo. edições raras são concedidas por terminar uma seção sem errar nenhuma resposta.",
   },
   track: {
     backToPath: "trilha da campanha",


### PR DESCRIPTION
Found by sweeping every **value** in the EN and PT message trees (keys excluded
— those are not user-visible, and several are still named `skirmish*`, which is
fine). Eleven strings, most fixed in one locale and not the other:

| key | was |
|---|---|
| `lesson.incorrect` | EN "study the rune again" |
| `lesson.doneSignedIn` | EN "the beacon flickers … the Ledgerstone" |
| `lesson.mentorUnavailable` | EN "away from the forge — the scroll's hints" |
| `lesson.backToAct` | EN + PT said "act" where the app says section |
| `journey.player.branch.locked` | EN + PT, same |
| `home.doors.campaign.progress` | PT "atos vencidos" vs EN "sections cleared" |
| `onboarding.welcomeBody3` | EN + PT "one small rune at a time" |
| `onboarding.xpLevels[0].blurb` | EN + PT "never written a rune … the Citadel" |
| `onboarding.proofHeading` | PT "os anciões já forjaram muitos aprendizes" |
| `pages.campaign.optionalNote` | PT still counted in "atos" |
| `pages.cards.footnote` | PT still promised on-chain card claiming, which EN deliberately dropped |

That last one mattered most: the two locales were describing different products.

`landing.*` is deliberately untouched. The campaign genuinely still has acts,
champion cards and the Beholder, and the art is named for them — only the words
the app itself no longer uses were aligned there, in the previous pass. Whether
the landing should stop selling the campaign framing altogether is a positioning
decision, not a consistency bug.

`pages.track.overlord` is left as `"{overlord}"`: it is a format string, and
every act now has `overlord: null`, so it never renders.