### PR TITLE
ci: actually gate the Advanced Path's 87 lessons

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,16 @@ name: Rust
 
 on:
   pull_request:
-    paths: ["runner/**", "runner-soroban/**"]
+    paths:
+      - "runner/**"
+      - "runner-soroban/**"
+      # check-advanced-content lives here rather than in ci.yml because it
+      # needs cargo to build tusst-checkfile; ci.yml's runner has no Rust
+      # toolchain, so the gate would degrade to a warning there and guard
+      # nothing. Trade-off: a content-only PR also runs the audit jobs.
+      - "src/content/advanced/**"
+      - "src/content/lesson-checks.ts"
+      - "scripts/check-advanced.ts"
   schedule:
     # Weekly, independent of any code change — the point is to catch newly
     # published advisories against dependencies that have been pinned and
@@ -51,6 +60,42 @@ jobs:
       # resolve to something else.
       - run: cargo test --workspace --locked
         working-directory: runner
+
+  check-advanced-content:
+    # The Advanced Path's 87 lessons each make three promises at once: the AST
+    # checks describe a solvable shape, the reference solution compiles under
+    # the sandbox's exact rustc flags, and its stdout matches expectedOutput
+    # byte for byte. Until now nothing enforced any of that in CI — the script
+    # existed and was invoked from nowhere but package.json, so the guarantee
+    # was only ever as good as the last person who remembered to run it.
+    #
+    # `--strict` is what makes this a gate rather than a formality: it turns
+    # every "toolchain missing, skipping" into an error and asserts that both
+    # sections covered every sandbox lesson. Without it a skipped section still
+    # prints "advanced content OK" and exits 0.
+    runs-on: ubuntu-latest
+    env:
+      # prisma generate runs in postinstall and only reads schema.prisma, but
+      # Prisma 7 refuses to load its config at all without this set.
+      DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy?schema=public"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      # Same pin, same reason, as ci.yml and deploy.yml: Dependabot writes the
+      # lockfile with npm 11, and npm 10's `npm ci` rejects it as out of sync.
+      - run: npm install -g npm@11
+      - run: npm ci --no-audit --no-fund
+
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: runner
+
+      - run: npm run check:advanced -- --strict
 
   build-runner-soroban:
     runs-on: ubuntu-latest

--- a/scripts/check-advanced.ts
+++ b/scripts/check-advanced.ts
@@ -19,10 +19,23 @@
 //
 // Run: npm run check:advanced   (needs a local rustc for section 5 and cargo
 // for section 6; each skips with a clear warning if its toolchain is missing,
-// so the structural checks still guard CI)
+// so the structural checks still guard a machine without a Rust toolchain)
+//
+// Run: npm run check:advanced -- --strict   (CI)
+// In strict mode every skip becomes an error, and the script asserts that it
+// compiled AND verified every sandbox lesson. Without that assertion a skipped
+// section still prints "advanced content OK" and exits 0 — which is exactly
+// how a gate ends up guarding nothing while looking green.
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -33,8 +46,29 @@ import { advancedGraders } from "../src/content/advanced/graders";
 import { ptAdvancedSteps } from "../src/content/advanced/i18n/pt";
 import { ptAdvancedInstructions } from "../src/content/advanced/i18n/pt/instructions";
 
+const STRICT =
+  process.argv.includes("--strict") || process.env.CHECK_ADVANCED_STRICT === "1";
+
 const errors: string[] = [];
 const warnings: string[] = [];
+
+// Every sandbox lesson must be both compiled (section 5) and evaluated
+// (section 6). Tracked at module scope so the assertion at the bottom can see
+// them no matter which branch ran.
+const sandboxLessons = Object.values(advancedGraders).filter(
+  (c) => c.grader === "sandbox",
+).length;
+let compiledCount = 0;
+let verifiedCount = 0;
+
+/**
+ * A degradation, not a defect — unless we are in CI, where a toolchain that
+ * silently is not there is the whole failure mode this flag exists to catch.
+ */
+function skip(message: string) {
+  if (STRICT) errors.push(`${message} (fatal under --strict)`);
+  else warnings.push(message);
+}
 
 function check(condition: unknown, message: string) {
   if (!condition) errors.push(message);
@@ -242,9 +276,7 @@ for (const slug of Object.keys(ptAdvancedInstructions)) {
 // ---------------------------------------------------------------------------
 
 if (!hasRustc()) {
-  warnings.push(
-    "rustc not found — skipped compiling reference solutions (structure was still checked)",
-  );
+  skip("rustc not found — skipped compiling reference solutions");
 } else {
   const dir = mkdtempSync(join(tmpdir(), "tusst-advanced-"));
   let compiled = 0;
@@ -283,6 +315,7 @@ if (!hasRustc()) {
       }
       compiled++;
     }
+    compiledCount = compiled;
     console.log(`compiled and ran ${compiled} reference solution(s)`);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -320,9 +353,7 @@ function hasCargo(): boolean {
 // CI without cargo still gets every structural guarantee.
 function resolveCheckfile(): string | null {
   if (!existsSync(join(RUNNER_DIR, "Cargo.toml"))) {
-    warnings.push(
-      `runner workspace not found at ${RUNNER_DIR} — skipped AST-check verification`,
-    );
+    skip(`runner workspace not found at ${RUNNER_DIR} — skipped AST-check verification`);
     return null;
   }
 
@@ -330,12 +361,25 @@ function resolveCheckfile(): string | null {
   const releaseBin = join(RUNNER_DIR, "target", "release", "tusst-checkfile");
 
   if (!hasCargo()) {
-    // No cargo, but a previous build may have left the binary behind.
+    // No cargo, but a previous build may have left the binary behind. Only
+    // trust it if it is newer than every tusst-syntest source: a stale binary
+    // would bless all 87 lessons under the OLD normalization, which is the
+    // precise failure this section exists to catch.
     const prebuilt = [releaseBin, debugBin].find((p) => existsSync(p));
-    if (prebuilt) return prebuilt;
-    warnings.push(
-      "cargo not found — skipped AST-check verification (structure and reference solutions were still checked)",
-    );
+    if (prebuilt) {
+      const srcDir = join(RUNNER_DIR, "crates", "tusst-syntest", "src");
+      const newestSource = existsSync(srcDir)
+        ? Math.max(
+            ...readdirSync(srcDir).map((f) => statSync(join(srcDir, f)).mtimeMs),
+          )
+        : 0;
+      if (statSync(prebuilt).mtimeMs >= newestSource) return prebuilt;
+      skip(
+        `${prebuilt} is older than tusst-syntest's sources and cargo is unavailable to rebuild it — skipped AST-check verification rather than trust a stale evaluator`,
+      );
+      return null;
+    }
+    skip("cargo not found — skipped AST-check verification");
     return null;
   }
 
@@ -347,12 +391,19 @@ function resolveCheckfile(): string | null {
     { cwd: RUNNER_DIR, encoding: "utf8", timeout: 600_000 },
   );
   if (build.status !== 0) {
-    warnings.push(
+    skip(
       `could not build tusst-checkfile — skipped AST-check verification\n${(build.stderr || "").trim().split("\n").slice(0, 8).join("\n")}`,
     );
     return null;
   }
-  return existsSync(debugBin) ? debugBin : null;
+  if (existsSync(debugBin)) return debugBin;
+  // cargo said it built, but the binary is not where we look — CARGO_TARGET_DIR
+  // is the usual reason, and it is standard CI cache practice. This was the one
+  // bail-out that returned null in silence.
+  skip(
+    `cargo built tusst-checkfile but no binary at ${debugBin} — CARGO_TARGET_DIR is probably set; skipped AST-check verification`,
+  );
+  return null;
 }
 
 const checkfile = resolveCheckfile();
@@ -421,6 +472,7 @@ if (checkfile) {
       }
       verified++;
     }
+    verifiedCount = verified;
     console.log(`evaluated AST checks for ${verified} lesson(s)`);
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -428,6 +480,20 @@ if (checkfile) {
 }
 
 // ---------------------------------------------------------------------------
+
+// The assertion that makes every skip above impossible to ignore: if a section
+// ran but covered fewer lessons than exist, the counts disagree and the build
+// fails. A gate that can quietly verify nothing while printing OK is not a gate.
+if (STRICT) {
+  check(
+    compiledCount === sandboxLessons,
+    `compiled ${compiledCount} reference solution(s) but ${sandboxLessons} sandbox lesson(s) exist — section 5 did not cover everything`,
+  );
+  check(
+    verifiedCount === sandboxLessons,
+    `evaluated AST checks for ${verifiedCount} lesson(s) but ${sandboxLessons} sandbox lesson(s) exist — section 6 did not cover everything`,
+  );
+}
 
 for (const warning of warnings) console.warn(`! ${warning}`);
 
@@ -439,5 +505,9 @@ if (errors.length > 0) {
 
 const active = advancedTracks.filter((t) => t.status === "active");
 console.log(
-  `advanced content OK: ${active.length} active track(s), ${advancedLessonSlugs.length} lessons, ${advancedTracks.length - active.length} track(s) declared.`,
+  `advanced content OK: ${active.length} active track(s), ${advancedLessonSlugs.length} lessons, ` +
+    `${advancedTracks.length - active.length} track(s) declared, ` +
+    `${compiledCount}/${sandboxLessons} compiled, ${verifiedCount}/${sandboxLessons} AST-verified` +
+    (STRICT ? " [strict]" : "") +
+    ".",
 );


### PR DESCRIPTION
`check:advanced` was invoked from nowhere. `grep -rn "check:advanced"` found one
hit — `package.json:14`. Not ci.yml, not rust.yml, not vps-deploy.sh. The 87
lessons carried exactly the assurance of whoever last remembered to run it.

## Why rust.yml and not ci.yml

Section 6 builds `tusst-checkfile` to evaluate AST checks. ci.yml's runner has
no Rust toolchain, so the gate would degrade to a warning there and guard
nothing. The trigger now also watches `src/content/advanced/**`,
`lesson-checks.ts` and the script itself, so it fires on the PRs that add
lessons.

**Trade-off:** a content-only PR now also runs the audit jobs (~3 min, in
parallel). Splitting them behind `dorny/paths-filter` is possible later; it did
not seem worth restructuring a working workflow for that today.

## `--strict`

What makes this a gate rather than a formality:

- every "toolchain missing, skipping" becomes an error;
- after both sections, it asserts `compiled == verified == sandbox lesson count`.

**That assertion is the load-bearing part.** Without it a skipped section still
printed `advanced content OK` and exited 0, and three separate bail-outs could
reach that state — one of them (cargo built the binary but `CARGO_TARGET_DIR`
moved it) returning `null` in complete silence. `CARGO_TARGET_DIR` is standard
CI cache practice, i.e. precisely when you would wire this up.

## Stale-evaluator fix

The no-cargo branch reused a prebuilt `tusst-checkfile` three lines below a
comment promising it always rebuilds. A stale binary would bless all 87 lessons
under the **old** normalization — the exact failure section 6 exists to catch.
It now compares mtime against `tusst-syntest/src` and refuses rather than
trusting it.

Verified in the wild: with cargo hidden, that branch fired on this very tree,
because `tokens.rs` was edited after the last release build.

## Verified four ways

| | |
|---|---|
| strict + toolchain | exit 0, `87/87 compiled, 87/87 AST-verified [strict]` |
| strict, no toolchain | exit 1, naming all four gaps |
| non-strict, no toolchain | exit 0 — a dev machine without Rust keeps the structural checks |
| `expr_present` on an item declaration | rejected: *"malformed … It can never pass."* |

The success line now states coverage instead of an unqualified OK.